### PR TITLE
Fix typo on JavaScript

### DIFF
--- a/Config/GraphiQLViewConfig.php
+++ b/Config/GraphiQLViewConfig.php
@@ -4,24 +4,24 @@ namespace Overblog\GraphiQLBundle\Config;
 
 final class GraphiQLViewConfig
 {
-    /** @var GraphiQLViewJavascriptLibraries */
-    private $javascriptLibraries;
+    /** @var GraphiQLViewJavaScriptLibraries */
+    private $javaScriptLibraries;
 
     /** @var string */
     private $template;
 
-    public function __construct(GraphiQLViewJavascriptLibraries $javascriptLibraries, $template)
+    public function __construct(GraphiQLViewJavaScriptLibraries $javaScriptLibraries, $template)
     {
-        $this->javascriptLibraries = $javascriptLibraries;
+        $this->javaScriptLibraries = $javaScriptLibraries;
         $this->template = $template;
     }
 
     /**
-     * @return GraphiQLViewJavascriptLibraries
+     * @return GraphiQLViewJavaScriptLibraries
      */
-    public function getJavascriptLibraries()
+    public function getJavaScriptLibraries()
     {
-        return $this->javascriptLibraries;
+        return $this->javaScriptLibraries;
     }
 
     /**

--- a/Config/GraphiQLViewJavaScriptLibraries.php
+++ b/Config/GraphiQLViewJavaScriptLibraries.php
@@ -2,7 +2,7 @@
 
 namespace Overblog\GraphiQLBundle\Config;
 
-final class GraphiQLViewJavascriptLibraries
+final class GraphiQLViewJavaScriptLibraries
 {
     /** @var string */
     private $graphiQLVersion;

--- a/Controller/GraphiQLController.php
+++ b/Controller/GraphiQLController.php
@@ -43,9 +43,9 @@ final class GraphiQLController
             [
                 'endpoint' => $endpoint,
                 'versions' => [
-                    'graphiql' => $this->viewConfig->getJavascriptLibraries()->getGraphiQLVersion(),
-                    'react' => $this->viewConfig->getJavascriptLibraries()->getReactVersion(),
-                    'fetch' => $this->viewConfig->getJavascriptLibraries()->getFetchVersion(),
+                    'graphiql' => $this->viewConfig->getJavaScriptLibraries()->getGraphiQLVersion(),
+                    'react' => $this->viewConfig->getJavaScriptLibraries()->getReactVersion(),
+                    'fetch' => $this->viewConfig->getJavaScriptLibraries()->getFetchVersion(),
                 ],
             ]
         ));

--- a/Resources/config/schema/overblog_graphiql-0.1.xsd
+++ b/Resources/config/schema/overblog_graphiql-0.1.xsd
@@ -13,7 +13,7 @@
         </xsd:restriction>
     </xsd:simpleType>
 
-    <xsd:complexType name="javascriptLibraries">
+    <xsd:complexType name="javaScriptLibraries">
         <xsd:attribute name="graphiql" type="xsd:token"/>
         <xsd:attribute name="react" type="xsd:token"/>
         <xsd:attribute name="fetch" type="xsd:token"/>
@@ -23,7 +23,7 @@
     <xsd:complexType name="config">
         <xsd:choice maxOccurs="unbounded">
             <xsd:element name="template" type="xsd:string" minOccurs="0" maxOccurs="1" />
-            <xsd:element name="javascript_libraries" type="javascriptLibraries" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="javascript_libraries" type="javaScriptLibraries" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
     </xsd:complexType>
 </xsd:schema>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,7 @@
                  autowire="false" public="false">
         </service>
         <service id="overblog_graphiql.view.config.javascript_libraries"
-                 class="Overblog\GraphiQLBundle\Config\GraphiQLViewJavascriptLibraries"
+                 class="Overblog\GraphiQLBundle\Config\GraphiQLViewJavaScriptLibraries"
                  autowire="false" public="false">
         </service>
         <service id="overblog_graphiql.controller"

--- a/Tests/DependencyInjection/OverblogGraphiQLExtensionTest.php
+++ b/Tests/DependencyInjection/OverblogGraphiQLExtensionTest.php
@@ -3,7 +3,7 @@
 namespace Overblog\GraphiQLBundle\Tests\DependencyInjection;
 
 use Overblog\GraphiQLBundle\Config\GraphiQLViewConfig;
-use Overblog\GraphiQLBundle\Config\GraphiQLViewJavascriptLibraries;
+use Overblog\GraphiQLBundle\Config\GraphiQLViewJavaScriptLibraries;
 use Overblog\GraphiQLBundle\DependencyInjection\OverblogGraphiQLExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,7 +21,7 @@ final class OverblogGraphiQLExtensionTest extends TestCase
 
         $jsLibraries = $container->get('overblog_graphiql.view.config.javascript_libraries');
 
-        $this->assertInstanceOf(GraphiQLViewJavascriptLibraries::class, $jsLibraries);
+        $this->assertInstanceOf(GraphiQLViewJavaScriptLibraries::class, $jsLibraries);
         $this->assertSame('2.0', $jsLibraries->getFetchVersion());
         $this->assertSame('15.6', $jsLibraries->getReactVersion());
         $this->assertSame('0.11', $jsLibraries->getGraphiQLVersion());
@@ -30,7 +30,7 @@ final class OverblogGraphiQLExtensionTest extends TestCase
 
         $this->assertInstanceOf(GraphiQLViewConfig::class, $viewConfig);
         $this->assertSame('@OverblogGraphiQL/GraphiQL/index.html.twig', $viewConfig->getTemplate());
-        $this->assertSame($jsLibraries, $viewConfig->getJavascriptLibraries());
+        $this->assertSame($jsLibraries, $viewConfig->getJavaScriptLibraries());
 
         $controllerDefinition = $container->getDefinition('overblog_graphiql.controller');
         $viewConfigArgument = $controllerDefinition->getArgument(1);


### PR DESCRIPTION
JavaScript must be written with a capital S.