### PR TITLE
[Configuration] Removed relay version option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,7 +25,6 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('graphiql')->defaultValue('0.11')->end()
                         ->scalarNode('react')->defaultValue('15.6')->end()
                         ->scalarNode('fetch')->defaultValue('2.0')->end()
-                        ->enumNode('relay')->values(['modern', 'classic'])->defaultValue('classic')->end()
                     ->end()
                 ->end()
             ->end()

--- a/Resources/config/schema/overblog_graphiql-0.1.xsd
+++ b/Resources/config/schema/overblog_graphiql-0.1.xsd
@@ -6,18 +6,10 @@
 
     <xsd:element name="config" type="config" />
 
-    <xsd:simpleType name="relayMode">
-        <xsd:restriction base="xsd:token">
-            <xsd:enumeration value="modern" />
-            <xsd:enumeration value="classic" />
-        </xsd:restriction>
-    </xsd:simpleType>
-
     <xsd:complexType name="javaScriptLibraries">
         <xsd:attribute name="graphiql" type="xsd:token"/>
         <xsd:attribute name="react" type="xsd:token"/>
         <xsd:attribute name="fetch" type="xsd:token"/>
-        <xsd:attribute name="relay" type="relayMode"/>
     </xsd:complexType>
 
     <xsd:complexType name="config">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

- As in the GraphQLBundle we don't support relay version in the configuration anymore 

