### PR TITLE
Make it possible to configure a endpoint resolver for graphiql

### DIFF
--- a/DependencyInjection/Compiler/Endpoints/OverblogGraphQLBundleEndpointWiringPass.php
+++ b/DependencyInjection/Compiler/Endpoints/OverblogGraphQLBundleEndpointWiringPass.php
@@ -2,7 +2,6 @@
 
 namespace Overblog\GraphiQLBundle\DependencyInjection\Compiler\Endpoints;
 
-use Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\OverblogGraphQLBundleEndpointResolver;
 use Overblog\GraphiQLBundle\Config\GraphQLEndpoint\RouteResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/DependencyInjection/Compiler/Endpoints/OverblogGraphQLBundleEndpointWiringPass.php
+++ b/DependencyInjection/Compiler/Endpoints/OverblogGraphQLBundleEndpointWiringPass.php
@@ -23,7 +23,7 @@ final class OverblogGraphQLBundleEndpointWiringPass implements CompilerPassInter
 
         $endpointDefinition->setArguments([
             new Reference('router'),
-            [OverblogGraphQLBundleEndpointResolver::class, 'getByName'],
+            [$container->getParameter('overblog_graphiql.endpoint_resolver'), 'getByName'],
         ]);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace Overblog\GraphiQLBundle\DependencyInjection;
 
+use Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\EndpointResolverInterface;
+use Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\OverblogGraphQLBundleEndpointResolver;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -15,6 +17,9 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()
+                ->scalarNode('endpoint_resolver')
+                    ->defaultValue(OverblogGraphQLBundleEndpointResolver::class)
+                ->end()
                 ->scalarNode('template')
                     ->info('In case you need it\'s possible to replace GraphiQL twig template')
                     ->defaultValue('@OverblogGraphiQL/GraphiQL/index.html.twig')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Overblog\GraphiQLBundle\DependencyInjection;
 
-use Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\EndpointResolverInterface;
 use Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\OverblogGraphQLBundleEndpointResolver;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/DependencyInjection/OverblogGraphiQLExtension.php
+++ b/DependencyInjection/OverblogGraphiQLExtension.php
@@ -21,6 +21,8 @@ class OverblogGraphiQLExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        $container->setParameter('overblog_graphiql.endpoint_resolver', $config['endpoint_resolver']);
+
         $graphiQLViewConfigJSLibraries = $container->getDefinition('overblog_graphiql.view.config.javascript_libraries');
         $graphiQLViewConfigJSLibraries->setArguments([
             $config['javascript_libraries']['graphiql'],

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class AppKernel extends Kernel
 }
 ```
 
-**c)** Enable GraphiQL endpoint
+**b)** Enable GraphiQL endpoint
 
 ```yaml
 # in app/config/routing_dev.yml
@@ -87,6 +87,7 @@ More
 
 * [Custom HTTP headers](Resources/doc/custom-http-headers.md)
 * [Define JavaScript libraries' versions](Resources/doc/libraries-versions.md)
+* [Define a custom GraphQL endpoint](Resources/doc/graphql-endpoint.md)
 
 Community
 ---------

--- a/Resources/doc/graphql-endpoint.md
+++ b/Resources/doc/graphql-endpoint.md
@@ -1,0 +1,50 @@
+Custom GraphQL endpoint
+=======
+
+If your graphql endpoint is not the default one coming with the
+[overblog/graphql-bundle](https://github.com/overblog/GraphQLBundle), then you might want to tell graphiql how to
+resolve the route depending on a schema name.
+
+By default it uses `Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\OverblogGraphQLBundleEndpointResolver`.
+
+### Configuration
+
+Just set the `overblog_graphiql.endpoint_resolver` parameter like this:
+
+```yaml
+# in app/config/config.yml
+overblog_graphiql:
+    ....
+    endpoint_resolver: \App\GraphiQL\EndpointResolver
+```
+
+### The Resolver
+
+The resolver must be something like this:
+
+```php
+<?php
+
+namespace App\GraphiQL;
+
+class EndpointResolver
+{
+    public static function getByName($name)
+    {
+        if ('default' === $name) {
+            return [
+                'overblog_graphql_endpoint',
+            ];
+        }
+
+        return [
+            'graphql_default',
+            ['schemaName' => $name],
+        ];
+    }
+}
+```
+
+It must return an array of packed params which will be passed to `RouterInterface::generate` like this
+`$router->generate(...$returnedValueOfTheGetByNameMethod)`.
+ 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documented?   | yes
| Fixed tickets | 
| License       | MIT

This PR helps in setting a Endpoint Resolver which will be used by graphiql to reach your GraphiQL endpoint. 

It has to be defined like this 

```
overblog_graphiql:
    ....
    endpoint_resolver: \App\GraphiQL\EndpointResolver
```
If it is not set, it will fall back to `Overblog\GraphiQLBundle\Config\GraphQLEndpoint\Helpers\OverblogGraphQLBundleEndpointResolver`

And the class itself might be something like this:

```
<?php

namespace App\GraphiQL;

class EndpointResolver
{
    public static function getByName($name)
    {
        if ('default' === $name) {
            return [
                'overblog_graphql_endpoint',
            ];
        }

        return [
            'graphql_default',
            ['schemaName' => $name],
        ];
    }
}
```

It must return an array of packed params which will be passed to `RouterInterface::generate` like this `$router->generate(...$returnedValueOfTheGetByNameMethod)`