### PR TITLE
User Deprecated: Referencing controllers with a single colon is deprecated since Symfony 4.1.

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -5,10 +5,10 @@
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="overblog_graphiql_endpoint" path="/graphiql">
-        <default key="_controller">overblog_graphiql.controller:indexAction</default>
+        <default key="_controller">overblog_graphiql.controller::indexAction</default>
     </route>
 
     <route id="overblog_graphiql_endpoint_multiple" path="/graphiql/{schemaName}">
-        <default key="_controller">overblog_graphiql.controller:indexAction</default>
+        <default key="_controller">overblog_graphiql.controller::indexAction</default>
     </route>
 </routes>

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -5,10 +5,10 @@
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="overblog_graphiql_endpoint" path="/graphiql">
-        <default key="_controller">overblog_graphiql.controller::indexAction</default>
+        <default key="_controller">Overblog\GraphiQLBundle\Controller\GraphiQLController::indexAction</default>
     </route>
 
     <route id="overblog_graphiql_endpoint_multiple" path="/graphiql/{schemaName}">
-        <default key="_controller">overblog_graphiql.controller::indexAction</default>
+        <default key="_controller">Overblog\GraphiQLBundle\Controller\GraphiQLController::indexAction</default>
     </route>
 </routes>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,5 +24,9 @@
             <argument type="service" id="overblog_graphiql.view.config" />
             <argument type="service" id="overblog_graphiql.controller.graphql.endpoint" />
         </service>
+        <service id="Overblog\GraphiQLBundle\Controller\GraphiQLController"
+                 alias="overblog_graphiql.controller"
+                 public="true">
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | /no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... 
| License       | MIT

A new deprectated is coming with SF 4.1 ;-) 

> With Passion !
