### PR TITLE
Support React v16 and fetch v3

### DIFF
--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -13,9 +13,18 @@
     </style>
   <link href="https://unpkg.com/graphiql@{{ versions.graphiql }}/graphiql.css" rel="stylesheet">
   {% endblock style %}
-    <script src="https://unpkg.com/whatwg-fetch@{{ versions.fetch }}/fetch.js"></script>
-    <script src="https://unpkg.com/react@{{ versions.react }}/dist/react.min.js"></script>
-    <script src="https://unpkg.com/react-dom@{{ versions.react }}/dist/react-dom.min.js"></script>
+    {% if versions.fetch matches '/^[~^]?2/' %}
+      <script src="https://unpkg.com/whatwg-fetch@{{ versions.fetch }}/fetch.js"></script>
+    {% else %}
+      <script src="https://unpkg.com/whatwg-fetch@{{ versions.fetch }}/dist/fetch.umd.js"></script>
+    {% endif %}
+    {% if versions.react matches '/^[~^]?15/' %}
+      <script src="https://unpkg.com/react@{{ versions.react }}/dist/react.min.js"></script>
+      <script src="https://unpkg.com/react-dom@{{ versions.react }}/dist/react-dom.min.js"></script>
+    {% else %}
+      <script src="https://unpkg.com/react@{{ versions.react }}/umd/react.production.min.js"></script>
+      <script src="https://unpkg.com/react-dom@{{ versions.react }}/umd/react-dom.production.min.js"></script>
+    {% endif %}
     <script src="https://unpkg.com/graphiql@{{ versions.graphiql }}/graphiql.min.js"></script>
     <title>{% block title %}GraphiQL{% endblock title %}</title>
   {% endblock head %}


### PR DESCRIPTION
Current code is stuck to react v15 and fetch v2 due to how those
packages are made available on unpkg: URLs are not the same.

This commit allows to use react v16 and fetch v3 by inspecting required
version to include the proper URL.

The commit is done in a none-BC break approach. We could also change
default lib version to v16 and v3 and forget about supporting v15 and v2.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
