### PR TITLE
New interface to accept symfony dumb object into graphiql tab panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ Done
 
 It's done now, navigate to `/graphiql` in your project url
 
+Details: You can use graphiql panel to debug your application using symfony dumb.
+You can dump information anywhere and see the result into graphiql view.
+
 More
 ------------
 
+* [Custom Logo](Resources/doc/custom-logo.md)
 * [Custom HTTP headers](Resources/doc/custom-http-headers.md)
 * [Custom GraphiQL parameters](Resources/doc/custom-parameters.md)
 * [Define JavaScript libraries' versions](Resources/doc/libraries-versions.md)

--- a/Resources/doc/custom-logo.md
+++ b/Resources/doc/custom-logo.md
@@ -1,0 +1,22 @@
+Custom logo
+==============
+
+By default the GraphiQL header will display GraphiQL logo.
+
+You can change your logo using a custom variable on twig file.
+```twig
+{# templates/GraphiQL/index.html.twig #}
+{% extends '@OverblogGraphiQL/GraphiQL/index.html.twig' %}
+
+{% set logoPath = 'https://mylink.com/images/logo.png' %}
+```
+
+You can also work with local images
+You can change your logo using a custom variable on twig file.
+```twig
+{# templates/GraphiQL/index.html.twig #}
+{% extends '@OverblogGraphiQL/GraphiQL/index.html.twig' %}
+
+{# move the file mylogo.png to public folder #}
+{% set logoPath = 'mylogo.png' %}
+```

--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -4,12 +4,18 @@
   {% block head %}
   {% block style %}
     <style>
-      html, body {
+      html, body, #root {
         width: 100%;
         height: 100%;
         margin: 0;
         overflow: hidden;
       }
+       #root .footer {
+           top:0;
+           left:0;
+           position:absolute;
+           width:100%;
+       }
     </style>
   <link href="https://unpkg.com/graphiql@{{ versions.graphiql }}/graphiql.css" rel="stylesheet">
   {% endblock style %}
@@ -30,6 +36,7 @@
   {% endblock head %}
 </head>
 <body>
+    <div id="root"></div>
 {% block body %}
   {% block body_loading %}Loading...{% endblock body_loading %}
   {% block body_script %}
@@ -47,6 +54,9 @@
           }
           {% endblock graphql_fetcher_headers %}
 
+            var footer = document.getElementsByClassName('footer');
+            footer = footer[0] || null;
+
           return fetch(endpoint, {
               method: "post",
               headers: headers,
@@ -54,11 +64,18 @@
               credentials: 'include',
             }).then((res) => {
               {% block post_fetch %}{% endblock post_fetch %}
+              footer.innerHTML = '';
               return res.text()
             }).then((body) => {
             try {
               return JSON.parse(body)
             } catch (err) {
+                if(typeof(body) === 'string'){
+                    if(footer){
+                        footer.innerHTML += body;
+                    }
+                    return '';
+                }
               return body
             }
           })
@@ -66,13 +83,31 @@
         }
 
       ReactDOM.render(
-        React.createElement(GraphiQL, {
-          {% block graphiql_params %}
-          fetcher: graphQLFetcher
-          {% endblock graphiql_params %}
-        }),
-        document.body
+        React.createElement(GraphiQL,
+            {
+                {% block graphiql_params %}
+                fetcher: graphQLFetcher
+                {% endblock graphiql_params %}
+            },
+            {%if logoPath is defined %}
+                React.createElement(
+                  GraphiQL.Logo,
+                  {},
+                  React.createElement(
+                      'img',
+                      {src:"{{ logoPath }}" }
+                  )
+              ),
+            {% endif %}
+            React.createElement(
+                GraphiQL.Footer,
+                {},
+                ''
+            )
+        ),
+        document.getElementById('root')
       )
+
     </script>
   {% endblock body_script %}
 {% endblock body %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?           |no
| New feature?  |yes
| BC breaks?      |no
| Deprecations? |no
| Tests pass?     |yes
| Documented? |yes
| License       | MIT

This PR helps to debug Symfony application using graphiql bundle.

I am using Graphiql footer to inject Symfony dump objects to react graphiql tab panel.
I had to use this strategy because i can't change React Graphiql tab result.

![image](https://user-images.githubusercontent.com/29734167/81961645-06aad900-95e9-11ea-916f-450d6455d971.png)

Its no need any extra configuration since graphql resolver sends an object as result, if we got a string i will inject outside react GraphiQL component.

Also, this PR allows you using a custom variable inside twig to put your custom logo inside GraphiQL.

You can change your logo using a custom variable on twig file.
```yaml
{# templates/GraphiQL/index.html.twig #}
{% set logoPath = 'https://mylink.com/images/logo.png' %}
```
You can also work with local images You can change your logo using a custom variable on twig file.
```yaml
{# templates/GraphiQL/index.html.twig #}
{# move the file mylogo.png to public folder #}
{% set logoPath = 'mylogo.png' %}
```