### PR TITLE
Fix links to docs chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ It's done now, navigate to `/graphiql` in your project url
 More
 ------------
 
-* [Custom HTTP headers](Resources/doc/custom-http-headers.md)
-* [Custom GraphiQL parameters](Resources/doc/custom-parameters.md)
-* [Define JavaScript libraries' versions](Resources/doc/libraries-versions.md)
-* [Define a custom GraphQL endpoint](Resources/doc/graphql-endpoint.md)
+* [Custom HTTP headers](src/Resources/doc/custom-http-headers.md)
+* [Custom GraphiQL parameters](src/Resources/doc/custom-parameters.md)
+* [Define JavaScript libraries' versions](src/Resources/doc/libraries-versions.md)
+* [Define a custom GraphQL endpoint](src/Resources/doc/graphql-endpoint.md)
 
 Community
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
There is no docs for custom parameters and custom GraphQL endpoint, which were dropped in https://github.com/overblog/GraphiQLBundle/commit/1f7030574cb99dda2e1c8d24175c8dc89a5df865#diff-769b4cd82eac8712bf35bb9c552175b94ae31871b6e3dd20fdbe7f1994172e12
Was it on purpose? Should we drop their mention from readme?