### PR TITLE
chore(dependencies): add symfony 7 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,25 +22,25 @@
     },
     "require": {
         "php": "^8.0",
-        "symfony/http-foundation": "^5.3.7 || ^6.0",
-        "symfony/twig-bundle": "^5.3.7 || ^6.0",
-        "symfony/routing": "^5.3.7 || ^6.0"
+        "symfony/http-foundation": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/twig-bundle": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/routing": "^5.3.7 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "overblog/graphql-bundle": "dev-master",
         "webonyx/graphql-php": "dev-master",
         "phpunit/phpunit": "^9.5.10",
         "sensio/framework-extra-bundle": "^6.2",
-        "symfony/browser-kit": "^5.3 || ^6.0",
-        "symfony/config": "^5.3.7 || ^6.0",
-        "symfony/console": "^5.3.7 || ^6.0",
-        "symfony/dependency-injection": "^5.3.7 || ^6.0",
-        "symfony/dom-crawler": "^5.3.7 || ^6.0",
-        "symfony/expression-language": "^5.3.7 || ^6.0",
-        "symfony/framework-bundle": "^5.3.7 || ^6.0",
-        "symfony/finder": "^5.3.7 || ^6.0",
-        "symfony/templating": "^5.3.7 || ^6.0",
-        "symfony/yaml": "^5.3.7 || ^6.0",
+        "symfony/browser-kit": "^5.3 || ^6.0 || ^7.0",
+        "symfony/config": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/console": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/dom-crawler": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/expression-language": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/finder": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/templating": "^5.3.7 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.3.7 || ^6.0 || ^7.0",
         "twig/twig": "^3.3.3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #39
| License       | MIT

Adjust composer.json to be compatible with Symfony 7