### PR TITLE
Add PHP configuration file support to remove Sf 7.4 XML deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.0",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
         "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
-        "symfony/routing": "^5.4 || ^6.0 || ^7.00"
+        "symfony/routing": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "overblog/graphql-bundle": "dev-master",

--- a/src/DependencyInjection/OverblogGraphiQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphiQLExtension.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphiQLBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 
 class OverblogGraphiQLExtension extends Extension
@@ -20,8 +20,8 @@ class OverblogGraphiQLExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.xml');
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.php');
 
         $container->setParameter('overblog_graphiql.endpoint_resolver', $config['endpoint_resolver']);
 

--- a/src/Resources/config/routing.php
+++ b/src/Resources/config/routing.php
@@ -1,0 +1,24 @@
+<?php
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\Loader\XmlFileLoader;
+
+return function (RoutingConfigurator $routes): void {
+    foreach (debug_backtrace() as $trace) {
+        if (isset($trace['object']) && $trace['object'] instanceof XmlFileLoader && 'doImport' === $trace['function']) {
+            if (__DIR__ === dirname(realpath($trace['args'][3]))) {
+                trigger_deprecation('symfony/routing', '7.3', 'The "routing.xml" routing configuration file is deprecated, import "routing.php" instead.');
+
+                break;
+            }
+        }
+    }
+
+    $routes->add('overblog_graphiql_endpoint', '/graphiql')
+        ->controller('overblog_graphiql.controller::indexAction')
+    ;
+
+    $routes->add('overblog_graphiql_endpoint_multiple', '/graphiql/{schemaName}')
+        ->controller('overblog_graphiql.controller::indexAction')
+    ;
+};

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('overblog_graphiql.controller.graphql.endpoint', \Overblog\GraphiQLBundle\Config\GraphiQLControllerEndpoint::class)
+        ->private()
+        ->autowire(false)
+    ;
+
+    $services->set('overblog_graphiql.view.config', \Overblog\GraphiQLBundle\Config\GraphiQLViewConfig::class)
+        ->private()
+        ->autowire(false)
+    ;
+
+    $services->set('overblog_graphiql.view.config.javascript_libraries', \Overblog\GraphiQLBundle\Config\GraphiQLViewJavaScriptLibraries::class)
+        ->private()
+        ->autowire(false)
+    ;
+
+    $services->set('overblog_graphiql.controller', \Overblog\GraphiQLBundle\Controller\GraphiQLController::class)
+        ->public()
+        ->autowire(false)
+        ->args([
+            service('twig'),
+            service('overblog_graphiql.view.config'),
+            service('overblog_graphiql.controller.graphql.endpoint'),
+        ])
+    ;
+
+    $services->alias(\Overblog\GraphiQLBundle\Controller\GraphiQLController::class, 'overblog_graphiql.controller')
+        ->public()
+    ;
+};

--- a/tests/Functional/DependencyInjection/Fixtures/Php/TestKernel.php
+++ b/tests/Functional/DependencyInjection/Fixtures/Php/TestKernel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Overblog\GraphiQLBundle\Tests\Fixtures;
+namespace Overblog\GraphiQLBundle\Tests\Functional\DependencyInjection\Fixtures\Php;
 
 use Overblog\GraphiQLBundle\OverblogGraphiQLBundle;
 use Overblog\GraphiQLBundle\Tests\TestKernel as AbstractTestKernel;
@@ -27,12 +27,10 @@ final class TestKernel extends AbstractTestKernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
+        $loader->load(__DIR__.'/config.php');
         $loader->load(function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [
-                'secret' => 'test',
-                'test' => true,
                 'assets' => ['enabled' => false],
-                'router' => ['resource' => '%kernel.project_dir%/src/Resources/config/routing.php'],
             ]);
         });
     }

--- a/tests/Functional/DependencyInjection/Fixtures/Php/config.php
+++ b/tests/Functional/DependencyInjection/Fixtures/Php/config.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('framework', [
+        'test' => null,
+        'secret' => 'test',
+        'router' => [
+            'resource' => '%kernel.project_dir%/Resources/config/routing.xml',
+        ],
+        'profiler' => ['enabled' => false],
+        'assets' => ['enabled' => false],
+    ]);
+};

--- a/tests/Functional/DependencyInjection/Php/ConfigurationTest.php
+++ b/tests/Functional/DependencyInjection/Php/ConfigurationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphiQLBundle\Tests\Functional\DependencyInjection\Php;
+
+use Overblog\GraphiQLBundle\Tests\Functional\DependencyInjection\Fixtures\Php\TestKernel;
+use Overblog\GraphiQLBundle\Tests\TestCase;
+
+final class ConfigurationTest extends TestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function setUp(): void
+    {
+        static::bootKernel(['test_case' => str_replace('\\', '_', __NAMESPACE__)]);
+    }
+
+    public function testSuccessConfiguration(): void
+    {
+        /** @var TestKernel $kernel */
+        $kernel = static::$kernel;
+
+        $this->assertTrue($kernel->isBooted());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Add PHP configuration file support to remove Sf 7.4 XML deprecations